### PR TITLE
Decimals

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,9 +2,9 @@
 
 Very advanced project management tool; a TODO list in Markdown.
 
+- [ ] Decimals.
 - [ ] Handle overflow. (e.g. 25/3 = 8.3333...)
 - [ ] Improve floating point math. (e.g. 1.2 x 3 = 3.5999999999999996)
-- [ ] Decimals.
 - [ ] Number key input.
 - [ ] Test with React Testing Library.
 - [ ] Show previous operand (small) above current one.

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 Very advanced project management tool; a TODO list in Markdown.
 
 - [ ] Decimals. Try https://www.npmjs.com/package/decimal.js-light
-- [ ] Handle overflow. (e.g. 25/3 = 8.3333...)
 - [ ] Number key input.
 - [ ] Test with React Testing Library.
 - [ ] Show previous operand (small) above current one.

--- a/TODO.md
+++ b/TODO.md
@@ -10,5 +10,6 @@ Very advanced project management tool; a TODO list in Markdown.
 - [ ] Re-theme.
 - [ ] Percent button, maybe?
 - [ ] Learn about the M+/-, is that something worth including?
+- [ ] `npm audit`
 - [x] Implement very advanced project management system for Calculator.
 - [x] Handle overflow. (e.g. 25/3 = 8.3333...)

--- a/TODO.md
+++ b/TODO.md
@@ -3,6 +3,7 @@
 Very advanced project management tool; a TODO list in Markdown.
 
 - [ ] Handle overflow. (e.g. 25/3 = 8.3333...)
+- [ ] Improve floating point math. (e.g. 1.2 x 3 = 3.5999999999999996)
 - [ ] Decimals.
 - [ ] Number key input.
 - [ ] Test with React Testing Library.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@testing-library/jest-dom": "^5.15.1",
         "@testing-library/user-event": "^12.8.3",
+        "decimal.js-light": "^2.5.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-scripts": "4.0.3",
@@ -6778,6 +6779,11 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "node_modules/decode-uri-component": {
       "version": "0.2.0",
@@ -26601,6 +26607,11 @@
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
       "integrity": "sha512-V0pfhfr8suzyPGOx3nmq4aHqabehUZn6Ch9kyFpV79TGDTWFmHqUqXdabR7QHqxzrYolF4+tVmJhUG4OURg5dQ=="
+    },
+    "decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="
     },
     "decode-uri-component": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@testing-library/jest-dom": "^5.15.1",
     "@testing-library/user-event": "^12.8.3",
+    "decimal.js-light": "^2.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-scripts": "4.0.3",

--- a/src/components/Calculator.test.tsx
+++ b/src/components/Calculator.test.tsx
@@ -57,3 +57,21 @@ test("Pressing 9-5= displays 4", () => {
 
   expectOutput("4");
 });
+
+test("Pressing 1.2×3= displays 3.6", () => {
+  render(<Calculator />);
+
+  // Note the '×' is a times symbol not a regular x.
+  // You may need to copy-paste it specifically!
+  clickButtons(["1", ".", "2", "×", "3", "="]);
+
+  expectOutput("3.6");
+});
+
+test("Pressing 6.8÷4= displays 1.7", () => {
+  render(<Calculator />);
+
+  clickButtons(["6", ".", "8", "÷", "4", "="]);
+
+  expectOutput("1.7");
+});

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -6,8 +6,8 @@ function NumberButton({
   handler,
   n,
 }: {
-  handler: (n: number) => void;
-  n: number;
+  handler: (n: string) => void;
+  n: string;
 }) {
   return (
     <button className="button" onClick={() => handler(n)}>
@@ -31,43 +31,35 @@ function OperationButton({
 }
 
 function Calculator() {
-  const [value, setValue] = useState(0);
-  const [previous, setPrevious] = useState(0);
+  const [value, setValue] = useState("");
+  const [previous, setPrevious] = useState("0");
   const [operation, setOperation] = useState<Operation | null>(null);
   const [waiting, setWaiting] = useState(false);
-  const [decimalFactor, setDecimalFactor] = useState<number | null>(null);
 
   const handleAC = () => {
-    setValue(0);
-    setPrevious(0);
+    setValue("0");
+    setPrevious("0");
     setOperation(null);
     setWaiting(false);
-    setDecimalFactor(null);
   };
 
   const handleDelete = () => {
-    setValue(Math.floor(value / 10));
+    setValue(value.slice(0, -1));
   };
 
-  const handleNumber = (n: number) => {
+  const handleNumber = (n: string) => {
     if (waiting) {
       setWaiting(false);
-      setDecimalFactor(1);
-      setPrevious(decimalFactor ? value / decimalFactor : value);
+      setPrevious(value);
       setValue(n);
-    } else if (decimalFactor) {
-      setValue(value * 10 + n);
-      // Once you start adding digits after a decimal point,
-      // each one is ten times smaller in value than the last.
-      setDecimalFactor(decimalFactor * 10);
     } else {
-      setValue(value * 10 + n);
+      setValue(`${value}${n}`);
     }
   };
 
   const handleDecimal = () => {
-    if (!decimalFactor) {
-      setDecimalFactor(1);
+    if (!value.includes(".")) {
+      setValue(`${value}.`);
     }
   };
 
@@ -77,29 +69,28 @@ function Calculator() {
   };
 
   const handleEquals = () => {
+    const prev = parseFloat(previous);
+    const val = parseFloat(value);
     if (operation === "add") {
-      setValue(previous + value);
+      setValue(`${prev + val}`);
     }
     if (operation === "subtract") {
-      setValue(previous - value);
+      setValue(`${prev - val}`);
     }
     if (operation === "multiply") {
-      setValue(previous * value);
+      setValue(`${prev * val}`);
     }
     if (operation === "divide") {
-      setValue(previous / value);
+      setValue(`${prev / val}`);
     }
     setOperation(null);
     setWaiting(true);
-    setDecimalFactor(1);
   };
 
   return (
     <div className="calculator">
       <div className="display">
-        <span className="value">
-          {decimalFactor ? value / decimalFactor : value}
-        </span>
+        <span className="value">{value}</span>
       </div>
 
       <div className="row">
@@ -113,9 +104,9 @@ function Calculator() {
       </div>
 
       <div className="row">
-        <NumberButton handler={handleNumber} n={7} />
-        <NumberButton handler={handleNumber} n={8} />
-        <NumberButton handler={handleNumber} n={9} />
+        <NumberButton handler={handleNumber} n="7" />
+        <NumberButton handler={handleNumber} n="8" />
+        <NumberButton handler={handleNumber} n="9" />
         <OperationButton
           handler={() => handleOperation("multiply")}
           symbol="×"
@@ -123,9 +114,9 @@ function Calculator() {
       </div>
 
       <div className="row">
-        <NumberButton handler={handleNumber} n={4} />
-        <NumberButton handler={handleNumber} n={5} />
-        <NumberButton handler={handleNumber} n={6} />
+        <NumberButton handler={handleNumber} n="4" />
+        <NumberButton handler={handleNumber} n="5" />
+        <NumberButton handler={handleNumber} n="6" />
         <OperationButton
           handler={() => handleOperation("subtract")}
           symbol="−"
@@ -133,14 +124,14 @@ function Calculator() {
       </div>
 
       <div className="row">
-        <NumberButton handler={handleNumber} n={1} />
-        <NumberButton handler={handleNumber} n={2} />
-        <NumberButton handler={handleNumber} n={3} />
+        <NumberButton handler={handleNumber} n="1" />
+        <NumberButton handler={handleNumber} n="2" />
+        <NumberButton handler={handleNumber} n="3" />
         <OperationButton handler={() => handleOperation("add")} symbol="+" />
       </div>
 
       <div className="row">
-        <NumberButton handler={handleNumber} n={0} />
+        <NumberButton handler={handleNumber} n="0" />
         <button className="button" onClick={handleDecimal}>
           .
         </button>

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -35,16 +35,14 @@ function Calculator() {
   const [previous, setPrevious] = useState(0);
   const [operation, setOperation] = useState<Operation | null>(null);
   const [waiting, setWaiting] = useState(false);
-  const [decimalDenominator, setDecimalDenominator] = useState<number | null>(
-    null
-  );
+  const [decimalFactor, setDecimalFactor] = useState<number | null>(null);
 
   const handleAC = () => {
     setValue(0);
     setPrevious(0);
     setOperation(null);
     setWaiting(false);
-    setDecimalDenominator(null);
+    setDecimalFactor(null);
   };
 
   const handleDelete = () => {
@@ -54,22 +52,22 @@ function Calculator() {
   const handleNumber = (n: number) => {
     if (waiting) {
       setWaiting(false);
-      setDecimalDenominator(null);
-      setPrevious(value);
+      setDecimalFactor(1);
+      setPrevious(decimalFactor ? value / decimalFactor : value);
       setValue(n);
-    } else if (decimalDenominator) {
-      setValue(value + n / decimalDenominator);
+    } else if (decimalFactor) {
+      setValue(value * 10 + n);
       // Once you start adding digits after a decimal point,
       // each one is ten times smaller in value than the last.
-      setDecimalDenominator(decimalDenominator * 10);
+      setDecimalFactor(decimalFactor * 10);
     } else {
       setValue(value * 10 + n);
     }
   };
 
   const handleDecimal = () => {
-    if (!decimalDenominator) {
-      setDecimalDenominator(10);
+    if (!decimalFactor) {
+      setDecimalFactor(1);
     }
   };
 
@@ -93,13 +91,15 @@ function Calculator() {
     }
     setOperation(null);
     setWaiting(true);
-    setDecimalDenominator(null);
+    setDecimalFactor(1);
   };
 
   return (
     <div className="calculator">
       <div className="display">
-        <span className="value">{value}</span>
+        <span className="value">
+          {decimalFactor ? value / decimalFactor : value}
+        </span>
       </div>
 
       <div className="row">

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -1,6 +1,30 @@
 import { useState } from "react";
+import { Decimal } from "decimal.js-light";
 
 type Operation = "add" | "subtract" | "multiply" | "divide";
+
+const add = (a: string, b: string): string => {
+  return new Decimal(a).plus(new Decimal(b)).toString();
+};
+
+const subtract = (a: string, b: string): string => {
+  return new Decimal(a).minus(new Decimal(b)).toString();
+};
+
+const multiply = (a: string, b: string): string => {
+  return new Decimal(a).mul(new Decimal(b)).toString();
+};
+
+const divide = (a: string, b: string): string => {
+  return new Decimal(a).dividedBy(new Decimal(b)).toString();
+};
+
+const operations: Record<Operation, (a: string, b: string) => string> = {
+  add,
+  subtract,
+  multiply,
+  divide,
+};
 
 function NumberButton({
   handler,
@@ -69,19 +93,8 @@ function Calculator() {
   };
 
   const handleEquals = () => {
-    const prev = parseFloat(previous);
-    const val = parseFloat(value);
-    if (operation === "add") {
-      setValue(`${prev + val}`);
-    }
-    if (operation === "subtract") {
-      setValue(`${prev - val}`);
-    }
-    if (operation === "multiply") {
-      setValue(`${prev * val}`);
-    }
-    if (operation === "divide") {
-      setValue(`${prev / val}`);
+    if (operation) {
+      setValue(operations[operation](previous, value));
     }
     setOperation(null);
     setWaiting(true);


### PR DESCRIPTION
Decimals cause problems in JavaScript (not just JS) because of floating point maths. This PR installs decimal.js-light and uses it to do maths on strings.

I chose to use strings because it's easier to avoid the temptation to do maths on them with vanilla JavaScript. Keep all input as strings, then pass those to functions which do the maths and return a new string to display.